### PR TITLE
Detects nginx by examining running processes vs a PID file

### DIFF
--- a/NginxService/NginxController.cs
+++ b/NginxService/NginxController.cs
@@ -47,7 +47,7 @@ namespace NginxService
             Execute.UntilTrueOrTimeout(_nginxProcess.IsRunning, 10, TimeSpan.FromMilliseconds(250));
             if (!_nginxProcess.IsRunning())
             {
-                throw new FileNotFoundException("Failed to start the nginx process.");
+                throw new Exception("Failed to start the nginx process.");
             }
         }
 
@@ -66,17 +66,12 @@ namespace NginxService
             }
 
             // kill it
-            var service = Process.GetProcessesByName("nginxservice").FirstOrDefault();
-            if (service != null)
+            using (var service = Process.GetProcessesByName("nginxservice").FirstOrDefault())
             {
-                try
+                if (service != null)
                 {
                     service.Kill();
                     service.WaitForExit();
-                }
-                finally
-                {
-                    service.Dispose();
                 }
             }
         }

--- a/NginxService/NginxController.cs
+++ b/NginxService/NginxController.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 #if DEBUG
 using System.Diagnostics;
@@ -20,6 +22,7 @@ namespace NginxService
             Stop();
             StartMasterProcess();
             AssertNginxWasStarted();
+            HeartBeatCheck();
         }
 
         public void Stop()
@@ -44,7 +47,37 @@ namespace NginxService
             Execute.UntilTrueOrTimeout(_nginxProcess.IsRunning, 10, TimeSpan.FromMilliseconds(250));
             if (!_nginxProcess.IsRunning())
             {
-                throw new FileNotFoundException(string.Format("Failed to start the nginx process, nginx.pid file not found in {0}", _nginxProcess.GetNginxPidPath()));
+                throw new FileNotFoundException("Failed to start the nginx process.");
+            }
+        }
+
+        private void HeartBeatCheck(int wait = 0)
+        {
+            if (wait > 0)
+            {
+                System.Threading.Thread.Sleep(wait);
+            }
+
+            if (_nginxProcess.IsRunning())
+            {
+                // queue another heartbeat check
+                System.Threading.Tasks.Task.Run(() => HeartBeatCheck(1000));
+                return;
+            }
+
+            // kill it
+            var service = Process.GetProcessesByName("nginxservice").FirstOrDefault();
+            if (service != null)
+            {
+                try
+                {
+                    service.Kill();
+                    service.WaitForExit();
+                }
+                finally
+                {
+                    service.Dispose();
+                }
             }
         }
     }

--- a/NginxService/NginxExeLocator.cs
+++ b/NginxService/NginxExeLocator.cs
@@ -21,16 +21,6 @@ namespace NginxService
         }
 
         /// <summary>
-        /// Gets the full path to the nginx.pid file. Assumes this service executable is
-        /// in the same directory as nginx.exe
-        /// </summary>
-        /// <returns>The full path to nginx.pid</returns>
-        public string GetNginxPidPath()
-        {
-            return Path.Combine(GetCurrentExecutingDirectory(), "logs\\nginx.pid");
-        }
-
-        /// <summary>
         /// Gets the current assemblies current location (pre-shadow copy).
         /// </summary>
         /// <remarks>

--- a/NginxService/NginxMasterProcess.cs
+++ b/NginxService/NginxMasterProcess.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.IO;
 
 namespace NginxService
 {
@@ -8,6 +7,9 @@ namespace NginxService
         private readonly NginxExeLocator _nginxExeLocator = new NginxExeLocator();
         private Process _nginxProcess;
 
+        /// <summary>
+        /// Starts nginx if the process is not running
+        /// </summary>
         public void StartMasterProcess()
         {
             if (_nginxProcess == null)
@@ -29,6 +31,9 @@ namespace NginxService
             }
         }
 
+        /// <summary>
+        /// Stops nginx if the process is running
+        /// </summary>
         public void StopMasterProcess()
         {
             var signalProcess = new NginxSignalProcess();
@@ -41,14 +46,14 @@ namespace NginxService
             }
         }
 
+        /// <summary>
+        /// Checks to see if nginx is running as a process
+        /// </summary>
+        /// <returns></returns>
         public bool IsRunning()
         {
-            return File.Exists(_nginxExeLocator.GetNginxPidPath());
-        }
-
-        public string GetNginxPidPath()
-        {
-            return _nginxExeLocator.GetNginxPidPath();
+            var processes = Process.GetProcessesByName("nginx");
+            return processes.Length > 0;
         }
     }
 }


### PR DESCRIPTION
This change examines the running processes to see if `nginx` is actually running or not, instead of assuming so by the presence of a PID file.  If `nginx` is not found, then the service self-terminates.